### PR TITLE
Updated legal notice in footer.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ PHP web front-end for the OpenGL ES hardware capability database located at http
 Some security related files are obviously not included
 
 # Legal
-OpenGL is a registered trademark and the OpenGL ES logo is a trademark of Silicon Graphics Inc. used by permission by Khronos.
+OpenGL is a registered trademark and the OpenGL ES logo is a trademark of Hewlett Packard Enterprise used under license by Khronos.

--- a/footer.html
+++ b/footer.html
@@ -4,7 +4,7 @@
 		<a rel="license" href="https://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons Lizenzvertrag" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under the <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International Lizenz</a>.
 		<br><br>
 		glESCapsViewer OpenGL ES capabilities database - &copy; 2011-2024 by <a href="https://www.saschawillems.de/" target="blank">Sascha Willems</a><br>
-		OpenGL is a registered trademark and the OpenGL ES logo is a trademark of Silicon Graphics Inc. used by permission by Khronos.
+		OpenGL is a registered trademark and the OpenGL ES logo is a trademark of Hewlett Packard Enterprise used under license by Khronos.
 	</font>
 </div>
 </center>


### PR DESCRIPTION
Silicon Graphics Inc. went bankrupt years ago and the trademarks are now owned by Hewlett Packard Enterprise instead.

See footer at: https://www.khronos.org/opengl/